### PR TITLE
【暫定対応】cronプロセスをバックグラウンドで起動し証明書チェーン生成処理を定期実行させる

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,5 @@ RUN { crontab -l; echo "*/5 * * * * bash /usr/src/app/create-certificate-chain.b
 
 # Start a container with this line.
 RUN chmod +x /usr/src/app/starting.sh
+RUN chmod +x /usr/src/app/create-certificate-chain.bash
 CMD [ "/usr/src/app/starting.sh" ]

--- a/starting.sh
+++ b/starting.sh
@@ -3,4 +3,6 @@
 # Released under the MIT license.
 # https://opensource.org/licenses/mit-license.php
 
+cd /usr/src/app
+cron;
 npm start;


### PR DESCRIPTION
fix #1 
* `starting.sh` 中でcronプロセスをバックグラウンドで起動し、crontabで登録した証明書チェーン生成処理を定期実行させる
https://github.com/Personal-Data-Linkage-Module/pxr-certification-authority-service/blob/3ceef90eefd425c182137ec65fa6bcfa67ddb82a/Dockerfile#L65
* 本来はsupervisord等の導入を検討したほうが良い