### PR TITLE
commit modified version bugfix/#10

### DIFF
--- a/src/common/DoRequest.ts
+++ b/src/common/DoRequest.ts
@@ -8,6 +8,8 @@ import { systemLogger } from './logging';
 import AppError from './AppError';
 import Config from '../common/Config';
 const Message = Config.ReadConfig('./config/message.json');
+const dns = require('dns');
+dns.setDefaultResultOrder('ipv4first');
 /* eslint-enable */
 
 /**


### PR DESCRIPTION
# pullrequestタイトル
node18からipv6が優先することに伴いlocalhostの通信に失敗する。

# 概要
## 環境（UT実行バージョン）
- postgres: 15.6
```
$ psql --version
psql (PostgreSQL) 15.6
```
- node: v18.16.0
```
$ fnm use 18
Using Node v18.16.0
```

## 対処内容
- nodejsの通信をipv6優先→ipv4優先に修正した。
- src/common/DoRequest.ts内で以下を追記し、ipv4を優先して利用する設定を入れた。
```
const dns = require('dns');
dns.setDefaultResultOrder('ipv4first');
```

# コマンド実行結果
## npm install実行結果
```
$ npm install
npm WARN deprecated @types/helmet@4.0.0: This is a stub types definition. helmet provides its own type definitions, so you do not need
this installed.
npm WARN deprecated @babel/plugin-proposal-export-namespace-from@7.18.9: This proposal has been merged to the ECMAScript standard and t
hus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances,
 which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

added 990 packages, and audited 991 packages in 2m

156 packages are looking for funding
  run `npm fund` for details

3 moderate severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

```

## ビルド実行結果
```
$ npm run build

> certification-authority-service@1.0.0 build
> npm-run-all -s lint build:ts


> certification-authority-service@1.0.0 lint
> eslint ./src/index.ts src/**/*.ts


> certification-authority-service@1.0.0 build:ts
> node ./node_modules/typescript/bin/tsc

```

## UT実行結果
```
$ npm run test:unit

> certification-authority-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

 PASS  src/tests/03-01.Client.spec.ts (47.027 s)
 PASS  src/tests/02-01.Server.spec.ts (28.042 s)
 PASS  src/tests/01-01.Root.spec.ts
 PASS  src/tests/05-01.List.spec.ts
 PASS  src/tests/06-01.Distributed.spec.ts
 PASS  src/tests/07-01.Valid.spec.ts
 PASS  src/tests/04-01.Actor.spec.ts
 PASS  src/tests/05-03.List.ActorCode.spec.ts
 PASS  src/tests/02-03.Server.insertError.spec.ts
 PASS  src/tests/03-03.Client.insertError.spec.ts
 PASS  src/tests/03-08.Client.openSslError5.spec.ts
 PASS  src/tests/02-08.Server.openSslError5.spec.ts
 PASS  src/tests/01-03.Root.insertError.spec.ts
 PASS  src/tests/03-07.Client.openSslError4.spec.ts
 PASS  src/tests/02-07.Server.openSslError4.spec.ts
 PASS  src/tests/03-02.Client.dbError.spec.ts
 PASS  src/tests/02-02.Server.dbError.spec.ts
 PASS  src/tests/03-04.Client.openSslError.spec.ts
 PASS  src/tests/01-08.Root.openSslError5.spec.ts
 PASS  src/tests/03-06.Client.openSslError3.spec.ts
 PASS  src/tests/02-06.Server.openSslError3.spec.ts
 PASS  src/tests/02-04.Server.openSslError.spec.ts
 PASS  src/tests/01-07.Root.openSslError4.spec.ts
 PASS  src/tests/03-05.Client.openSslError2.spec.ts
 PASS  src/tests/02-05.Server.openSslError2.spec.ts
 PASS  src/tests/01-06.Root.openSslError3.spec.ts
 PASS  src/tests/06-03.Distributed.insertError.spec.ts
 PASS  src/tests/01-05.Root.openSslError2.spec.ts
 PASS  src/tests/03-09.Client.deleteError.spec.ts
 PASS  src/tests/02-09.Server.deleteError.spec.ts
 PASS  src/tests/01-02.Root.dbError.spec.ts
 PASS  src/tests/01-04.Root.openSslError.spec.ts
 PASS  src/tests/04-02.Actor.dbError.spec.ts
 PASS  src/tests/07-02.Valid.dbError.spec.ts
 PASS  src/tests/06-02.Distributed.dbError.spec.ts
 PASS  src/tests/05-02.List.dbError.spec.ts
---------------------------------|---------|----------|---------|---------|-------------------
File                             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------------------------|---------|----------|---------|---------|-------------------
All files                        |   99.65 |    97.98 |     100 |   99.63 |
 repositories                    |     100 |      100 |     100 |     100 |
  CertificateManageRepository.ts |     100 |      100 |     100 |     100 |
 resources                       |     100 |      100 |     100 |     100 |
  ActorController.ts             |     100 |      100 |     100 |     100 |
  ClientController.ts            |     100 |      100 |     100 |     100 |
  DistributedController.ts       |     100 |      100 |     100 |     100 |
  ListController.ts              |     100 |      100 |     100 |     100 |
  RootController.ts              |     100 |      100 |     100 |     100 |
  ServerController.ts            |     100 |      100 |     100 |     100 |
  ValidController.ts             |     100 |      100 |     100 |     100 |
 resources/validator             |   97.88 |    96.55 |     100 |   97.76 |
  ClientRequestValidator.ts      |   97.87 |    97.05 |     100 |   97.77 | 124
  DistributedRequestValidator.ts |     100 |      100 |     100 |     100 |
  ServerRequestValidator.ts      |   95.91 |    94.28 |     100 |   95.74 | 90,128
  ValidRequestValidator.ts       |     100 |      100 |     100 |     100 |
 services                        |     100 |      100 |     100 |     100 |
  ActorService.ts                |     100 |      100 |     100 |     100 |
  ClientService.ts               |     100 |      100 |     100 |     100 |
  DistributedService.ts          |     100 |      100 |     100 |     100 |
  ListService.ts                 |     100 |      100 |     100 |     100 |
  OperatorService.ts             |     100 |      100 |     100 |     100 |
  RootService.ts                 |     100 |      100 |     100 |     100 |
  ServerService.ts               |     100 |      100 |     100 |     100 |
  ValidService.ts                |     100 |      100 |     100 |     100 |
---------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 36 passed, 36 total
Tests:       209 passed, 209 total
Snapshots:   0 total
Time:        177.395 s
Ran all test suites.

```